### PR TITLE
Childless

### DIFF
--- a/ingestors/__init__.py
+++ b/ingestors/__init__.py
@@ -17,7 +17,7 @@ def ingest(fio, file_path):
     :type fio: py:class:`io.FileIO`
     :param file_path: The file path.
     :type file_path: str
-    :return: A tuple with the ingestor object, its data and its children data.
+    :return: A tuple, the ingestor object, its data and detached ingestors data.
     :rtype: tuple
     """
     ingestor_class, mime_type = TextIngestor.match(fio)
@@ -27,6 +27,6 @@ def ingest(fio, file_path):
 
     ingestor = ingestor_class(fio, file_path, mime_type=mime_type)
     ingestor.run()
-    children_data = map(lambda c: c.result, ingestor.children)
+    detached_data = map(lambda c: c.result, getattr(ingestor, 'detached', []))
 
-    return ingestor, ingestor.result, children_data
+    return ingestor, ingestor.result, detached_data

--- a/ingestors/__init__.py
+++ b/ingestors/__init__.py
@@ -17,7 +17,7 @@ def ingest(fio, file_path):
     :type fio: py:class:`io.FileIO`
     :param file_path: The file path.
     :type file_path: str
-    :return: A tuple, the ingestor object, its data and detached ingestors data.
+    :return: Tuple, the ingestor object, its data and detached ingestors data.
     :rtype: tuple
     """
     ingestor_class, mime_type = TextIngestor.match(fio)

--- a/ingestors/cli/__init__.py
+++ b/ingestors/cli/__init__.py
@@ -18,10 +18,10 @@ def json_default(obj):
 def cli(file_path, echo=True):
     """CLI main method."""
     with io.open(file_path, 'rb') as fio:
-        ingestor, data, children_data = ingest(fio, file_path)
+        ingestor, data, detached_data = ingest(fio, file_path)
 
-        if children_data:
-            data['children'] = children_data
+        if detached_data:
+            data['pages'] = detached_data
 
         if not echo:
             return data

--- a/ingestors/doc.py
+++ b/ingestors/doc.py
@@ -9,6 +9,7 @@ class DocumentIngestor(PDFIngestor, OfficeSupport):
     """Office/Word document ingestor class.
 
     Converts the document to PDF and extracts the text.
+    Mostly a slightly adjusted PDF ingestor.
 
     Requires system tools:
 
@@ -58,9 +59,5 @@ class DocumentIngestor(PDFIngestor, OfficeSupport):
                     pdfio, pdf_path, temp_dir, config)
 
                 # Pass pages similar to the way PDF is handling it.
-                for page in self.xml_to_text(xml, page_selector):
-                    self.add_child(page, pdf_path, temp_dir, config)
-
-                for child in self.children:
-                    child.run()
-                    child.fio.close()
+                for page in self.xml_to_pages(xml, page_selector):
+                    self.add_page(page, pdf_path, temp_dir, config)

--- a/ingestors/ingestor.py
+++ b/ingestors/ingestor.py
@@ -111,21 +111,16 @@ class Ingestor(object):
         AssertionError
     ]
 
-    def __init__(self, fio, file_path, parent=None, mime_type=None):
+    def __init__(self, fio, file_path, mime_type=None):
         """Generic ingestor constructor class.
 
         :param fio: An instance of the file to process.
         :type fio: py:class:`io.FileIO`
         :param file_path: The file path.
         :type file_path: str
-        :param parent: Indicates parent file if this is was part of a composed
-                       file. Examples: archives, email files, etc.
-        :type parent: :py:class:`Ingestor`
         """
         self.fio = fio
         self.file_path = os.path.realpath(file_path)
-        self.parent = parent
-        self.children = []
         self.state = States.NEW
         self.status = Statuses.SUCCESS
         self.started_at = None
@@ -159,14 +154,6 @@ class Ingestor(object):
 
     def after(self):
         """Callback called after the processing starts."""
-        pass
-
-    def before_child(self):
-        """Callback called before the processing of a child file starts."""
-        pass
-
-    def after_child(self):
-        """Callback called after the processing of a child starts."""
         pass
 
     def exception_handler(self):

--- a/ingestors/ingestor.py
+++ b/ingestors/ingestor.py
@@ -130,7 +130,7 @@ class Ingestor(object):
 
         self.result = Result(mime_type=mime_type)
 
-        # Do not extract file info unless it is a new file
+        # Do not extract file info unless the ingestor is detached.
         if mime_type:
             self.result.extract_file_info(self.fio, self.file_path)
 
@@ -164,6 +164,23 @@ class Ingestor(object):
         """Extract and log the latest exception."""
         lines = traceback.format_exception(*sys.exc_info())
         self.logger.error('\n'.join(lines))
+
+    def detach(self, ingestor_class, fio, file_path, result_extra=None):
+        """Handles the processing/dispatching of the partial work/ingestion.
+
+        The current implementation is just for demo purposes.
+        Feel free to overwrite and provide a more effective implementation.
+        """
+        self.detached = getattr(self, 'detached', [])
+
+        ingestor = ingestor_class(fio=fio, file_path=file_path)
+        self.detached.append(ingestor)
+
+        if result_extra and isinstance(result_extra, dict):
+            ingestor.result.update(result_extra)
+
+        if ingestor_class is not Ingestor:
+            ingestor.run()
 
     def ingest(self, config):
         """The ingestor implementation. Should be overwritten.

--- a/ingestors/support/pdf.py
+++ b/ingestors/support/pdf.py
@@ -96,7 +96,7 @@ class PDFSupport(object):
         # worse results.
         pdftoppm = [
             bin_path,
-            '-f', pagenum,
+            '-f', str(pagenum),
             '-singlefile',
             '-r', '300',
             '-gray',

--- a/ingestors/support/xml.py
+++ b/ingestors/support/xml.py
@@ -44,7 +44,7 @@ class XMLSupport(object):
 
         return text.strip(), doc
 
-    def xml_to_text(self, xml, page_selector):
+    def xml_to_pages(self, xml, page_selector):
         parser = etree.XMLParser(recover=True, remove_comments=True)
         doc = etree.fromstring(xml, parser=parser)
 
@@ -53,7 +53,7 @@ class XMLSupport(object):
             yield page
 
     def page_to_text(self, page):
-        """Extracts (PDF) page content.
+        """Extracts (PDF converted to XML) page content.
 
         Returns the completion status, page number and the page text.
         If the status is not truthy, it requires extra processing (ex. OCR).

--- a/ingestors/support/xml.py
+++ b/ingestors/support/xml.py
@@ -45,6 +45,7 @@ class XMLSupport(object):
         return text.strip(), doc
 
     def xml_to_pages(self, xml, page_selector):
+        """Breaks a large XML into pages using an (lxml) selector."""
         parser = etree.XMLParser(recover=True, remove_comments=True)
         doc = etree.fromstring(xml, parser=parser)
 

--- a/ingestors/tabular.py
+++ b/ingestors/tabular.py
@@ -34,23 +34,27 @@ class TabularIngestor(Ingestor, OfficeSupport):
 
     def ingest(self, config):
         """Ingestor implementation."""
+        count = 0
+        self.result.columns = dict()
+
         tableset = self.tabular_to_tableset(
             self.fio, self.file_path, self.result.mime_type, config)
-
-        self.result.columns = dict()
-        count = 0
 
         for sheet_number, rowset in enumerate(tableset):
             self.result.columns[rowset.name] = False
 
             for mapping in self.sheet_row_to_dicts(sheet_number, rowset):
-                row_ingestor = Ingestor(self.fio, self.file_path)
-                row_ingestor.result.sheet_name = rowset.name
-                row_ingestor.result.sheet_number = sheet_number
-                row_ingestor.result.order = count
-                row_ingestor.result.content = mapping
-
-                self.children.append(row_ingestor)
+                self.detach(
+                    ingestor_class=Ingestor,
+                    fio=None,
+                    file_path=self.file_path,
+                    result_extra={
+                        'sheet_name': rowset.name,
+                        'sheet_number': sheet_number,
+                        'order': count,
+                        'content': mapping,
+                    }
+                )
 
                 if not self.result.columns.get(rowset.name):
                     self.result.columns[rowset.name] = mapping.keys()

--- a/tests/ingestors/test_cli.py
+++ b/tests/ingestors/test_cli.py
@@ -21,11 +21,11 @@ class CliTest(TestCase):
             'mime_type': 'text/plain'
         })
 
-    def test_cli_children(self):
+    def test_cli_pages(self):
         fixture_path = self.fixture('readme.pdf')
 
         data = cli.cli(fixture_path, echo=False)
-        children = data.pop('children')
+        pages = data.pop('pages')
 
         self.assertEqual(data, {
             'title': 'readme.pdf',
@@ -37,9 +37,9 @@ class CliTest(TestCase):
             'mime_type': 'application/pdf'
         })
 
-        self.assertIsNotNone(children[0].pop('content'))
+        self.assertIsNotNone(pages[0].pop('content'))
 
-        self.assertEqual(children[0], {
+        self.assertEqual(pages[0], {
             'news_keywords': None,
             'keywords': None,
             'description': None,

--- a/tests/ingestors/test_doc.py
+++ b/tests/ingestors/test_doc.py
@@ -33,14 +33,14 @@ class DocumentIngestorTest(TestCase):
             ing.run()
 
         self.assertIsNone(ing.result.content)
-        self.assertEqual(len(ing.children), 2)
+        self.assertEqual(len(ing.detached), 2)
         self.assertIn(
             u'This is a sample Microsoft Word Document.',
-            ing.children[0].result.content
+            ing.detached[0].result.content
         )
         self.assertIn(
             u'This one is in a different one, the Signature style',
-            ing.children[1].result.content
+            ing.detached[1].result.content
         )
 
     def test_ingest_presentation_doc(self):
@@ -53,11 +53,11 @@ class DocumentIngestorTest(TestCase):
         today = datetime.now()
 
         self.assertIsNone(ing.result.content)
-        self.assertEqual(len(ing.children), 1)
-        self.assertIn(u'Now', ing.children[0].result.content)
+        self.assertEqual(len(ing.detached), 1)
+        self.assertIn(u'Now', ing.detached[0].result.content)
         self.assertIn(
             today.strftime('%x %I:%M %p'),
-            ing.children[0].result.content
+            ing.detached[0].result.content
         )
 
     @skipUnless(TestCase.EXTRA_FIXTURES, 'No extra fixtures.')
@@ -70,7 +70,6 @@ class DocumentIngestorTest(TestCase):
 
         self.assertEqual(ing.status, DocumentIngestor.STATUSES.FAILURE)
         self.assertIsNone(ing.result.content)
-        self.assertEqual(len(ing.children), 0)
 
     @skipUnless(TestCase.EXTRA_FIXTURES, 'No extra fixtures.')
     def test_ingest_bad_doc(self):
@@ -82,7 +81,7 @@ class DocumentIngestorTest(TestCase):
 
         self.assertIsNone(ing.result.content)
         # TODO: This file should fail because it is just binary garbage.
-        self.assertEqual(len(ing.children), 117)
+        self.assertEqual(len(ing.detached), 117)
 
     @skipUnless(TestCase.EXTRA_FIXTURES, 'No extra fixtures.')
     def test_ingest_noisy_doc(self):
@@ -95,10 +94,10 @@ class DocumentIngestorTest(TestCase):
             ing.run()
 
         self.assertIsNone(ing.result.content)
-        self.assertEqual(len(ing.children), 1)
+        self.assertEqual(len(ing.detached), 1)
         self.assertIn(
             'We should paint graffiti on all corners',
-            ing.children[0].result.content
+            ing.detached[0].result.content
         )
 
     @skipUnless(TestCase.EXTRA_FIXTURES, 'No extra fixtures.')
@@ -112,8 +111,8 @@ class DocumentIngestorTest(TestCase):
             ing.run()
 
         self.assertIsNone(ing.result.content)
-        self.assertEqual(len(ing.children), 1)
-        self.assertIsNone(ing.children[0].result.content)
+        self.assertEqual(len(ing.detached), 1)
+        self.assertIsNone(ing.detached[0].result.content)
 
     @skipUnless(TestCase.EXTRA_FIXTURES, 'No extra fixtures.')
     def test_ingest_doc_with_images(self):
@@ -126,6 +125,6 @@ class DocumentIngestorTest(TestCase):
             ing.run()
 
         self.assertIsNone(ing.result.content)
-        self.assertEqual(len(ing.children), 1)
-        self.assertIn(u'42.', ing.children[0].result.content)
-        self.assertIn(u'zip.txt', ing.children[0].result.content)
+        self.assertEqual(len(ing.detached), 1)
+        self.assertIn(u'42.', ing.detached[0].result.content)
+        self.assertIn(u'zip.txt', ing.detached[0].result.content)

--- a/tests/ingestors/test_pdf.py
+++ b/tests/ingestors/test_pdf.py
@@ -27,11 +27,11 @@ class PDFIngestorTest(TestCase):
             ing.run()
 
         self.assertIsNone(ing.result.content)
-        self.assertEqual(len(ing.children), 1)
+        self.assertEqual(len(ing.detached), 1)
         self.assertIn(
             'Ingestors extract useful information'
             ' in a structured standard format',
-            ing.children[0].result.content
+            ing.detached[0].result.content
         )
 
     @skipUnless(TestCase.EXTRA_FIXTURES, 'No extra fixtures.')
@@ -44,9 +44,9 @@ class PDFIngestorTest(TestCase):
             ing.run()
 
         self.assertIsNone(ing.result.content)
-        self.assertEqual(len(ing.children), 500)
+        self.assertEqual(len(ing.detached), 500)
         self.assertEqual(
-            ing.children[0].result.content,
+            ing.detached[0].result.content,
             'Hello, World!\nHello, World!'
         )
 
@@ -59,10 +59,10 @@ class PDFIngestorTest(TestCase):
             ing.run()
 
         self.assertIsNone(ing.result.content)
-        self.assertEqual(len(ing.children), 588)
+        self.assertEqual(len(ing.detached), 588)
         self.assertIn(
             'ALGEBRA\nABSTRACT\nAND\nCONCRETE\nE\nDITION\n2.6',
-            ing.children[0].result.content
+            ing.detached[0].result.content
         )
 
     @skipUnless(TestCase.EXTRA_FIXTURES, 'No extra fixtures.')
@@ -74,17 +74,17 @@ class PDFIngestorTest(TestCase):
             ing.run()
 
         self.assertIsNone(ing.result.content)
-        self.assertEqual(len(ing.children), 6)
+        self.assertEqual(len(ing.detached), 6)
         self.assertIn(
             u'Würde und der gleichen und unveräußerlichen',
-            ing.children[0].result.content
+            ing.detached[0].result.content
         )
 
         cur_page = 1
-        for child in ing.children:
-            self.assertEqual(child.result.order, cur_page)
-            self.assertEqual(child.status, PDFIngestor.STATUSES.SUCCESS)
-            self.assertEqual(child.state, PDFIngestor.STATES.FINISHED)
+        for detached in ing.detached:
+            self.assertEqual(detached.result.order, cur_page)
+            self.assertEqual(detached.status, PDFIngestor.STATUSES.SUCCESS)
+            self.assertEqual(detached.state, PDFIngestor.STATES.FINISHED)
             cur_page += 1
 
     @skipUnless(TestCase.EXTRA_FIXTURES, 'No extra fixtures.')
@@ -96,7 +96,7 @@ class PDFIngestorTest(TestCase):
             ing.run()
 
         self.assertIsNone(ing.result.content)
-        self.assertEqual(len(ing.children), 15)
+        self.assertEqual(len(ing.detached), 15)
 
-        for child in ing.children:
-            self.assertIsNone(child.result.content)
+        for detached in ing.detached:
+            self.assertIsNone(detached.result.content)

--- a/tests/ingestors/test_tabular.py
+++ b/tests/ingestors/test_tabular.py
@@ -32,25 +32,25 @@ class TabularIngestorTest(TestCase):
             ing.run()
 
         self.assertIsNone(ing.result.content)
-        self.assertEqual(len(ing.children), 2)
+        self.assertEqual(len(ing.detached), 2)
         self.assertEqual(
             ing.result.columns['Sheet1'], [u'Name', u'Timestamp', u'Price'])
         self.assertEqual(
             ing.result.columns['Sheet2'], [u'Title', u'Price', u'Timestamp'])
 
-        self.assertEqual(ing.children[0].result.sheet_name, 'Sheet1')
-        self.assertEqual(ing.children[0].result.sheet_number, 0)
-        self.assertEqual(ing.children[0].result.order, 0)
-        self.assertEqual(dict(ing.children[0].result.content), {
+        self.assertEqual(ing.detached[0].result.sheet_name, 'Sheet1')
+        self.assertEqual(ing.detached[0].result.sheet_number, 0)
+        self.assertEqual(ing.detached[0].result.order, 0)
+        self.assertEqual(dict(ing.detached[0].result.content), {
             u'Name': u'Mihai Viteazul',
             u'Timestamp': datetime(1871, 12, 29, 13, 48),
             u'Price': 11.99
         })
 
-        self.assertEqual(ing.children[1].result.sheet_name, 'Sheet2')
-        self.assertEqual(ing.children[1].result.sheet_number, 1)
-        self.assertEqual(ing.children[1].result.order, 1)
-        self.assertEqual(ing.children[1].result.content, {
+        self.assertEqual(ing.detached[1].result.sheet_name, 'Sheet2')
+        self.assertEqual(ing.detached[1].result.sheet_number, 1)
+        self.assertEqual(ing.detached[1].result.order, 1)
+        self.assertEqual(ing.detached[1].result.content, {
             u'Title': u'Vlad Țepeș',
             u'Timestamp': datetime(1953, 9, 13, 22, 1),
             u'Price': 111
@@ -64,16 +64,16 @@ class TabularIngestorTest(TestCase):
             ing = TabularIngestor(fio, fixture_path)
             ing.run()
 
-        self.assertEqual(len(ing.children), 4)
+        self.assertEqual(len(ing.detached), 4)
         self.assertEqual(
             ing.result.columns['table'],
             [u'BEGDOC', u'ENDDOC', u'FILENAME',
              u'MODDATE', u'AUTHOR', u'DOCTYPE']
         )
-        self.assertEqual(ing.children[0].result.sheet_name, 'table')
-        self.assertEqual(ing.children[0].result.sheet_number, 0)
-        self.assertEqual(ing.children[0].result.order, 0)
-        self.assertEqual(dict(ing.children[0].result.content), {
+        self.assertEqual(ing.detached[0].result.sheet_name, 'table')
+        self.assertEqual(ing.detached[0].result.sheet_number, 0)
+        self.assertEqual(ing.detached[0].result.order, 0)
+        self.assertEqual(dict(ing.detached[0].result.content), {
             u'AUTHOR': u'J. Smith',
             u'BEGDOC': 1,
             u'DOCTYPE': u'docx',


### PR DESCRIPTION
After another review, we decided the child/parent approach is not sustainable.

This PR removes support for child/parent support and callbacks and provides an API method to handle the partial work an ingestor can generate (think of pages for big documents, sheets for excel files or archives with multiple files).

The `detach(...)` method logic and performance is out of the scope of this project at the moment, but developers should be able to provide a more effective implementation by simply overwriting the method.

/cc @pudo @mgax 