### PR TITLE
[WIP] Ingest outlook pst files using pypff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get -qq -y update \
         poppler-utils poppler-data pst-utils \
         # document processing
         libreoffice \
+        # libpff build tools
+        git autoconf automake autopoint libtool pkg-config \
     && apt-get -qq -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -36,6 +38,9 @@ ENV LANG='en_US.UTF-8' \
     LC_ALL='en_US.UTF-8'
 
 RUN pip3 install -q --upgrade pip setuptools six wheel
+RUN curl -SL "https://github.com/sunu/libpff/archive/master.tar.gz" | tar -xz -C /tmp/ && cd /tmp/libpff-master \
+    && ./synclibs.sh && ./autogen.sh && ./configure --enable-python \
+    && cd /tmp/libpff-master && python3 setup.py install
 RUN pip3 install -q banal>=0.3.4 \
                    normality>=0.5.11 \
                    celestial>=0.2.3 \

--- a/ingestors/email/msg.py
+++ b/ingestors/email/msg.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 class RFC822Ingestor(Ingestor, EmailSupport):
     MIME_TYPES = [
         'multipart/mixed',
+        'multipart/alternative',
         'message/rfc822'
     ]
     EXTENSIONS = [

--- a/ingestors/email/outlookpst.py
+++ b/ingestors/email/outlookpst.py
@@ -1,8 +1,6 @@
 import logging
 import os
 
-import pypff
-
 from ingestors.base import Ingestor
 from ingestors.support.temp import TempFileSupport
 from ingestors.support.outlookpst import OutlookPSTSupport
@@ -27,6 +25,8 @@ class OutlookPSTIngestor(Ingestor, TempFileSupport,
         self.result.flag(self.result.FLAG_PACKAGE)
         temp_dir = self.make_empty_directory()
         try:
+            # if installed with pip, pypff may not be available
+            import pypff
             pst_file = pypff.open(file_path)
             root = pst_file.get_root_folder()
             root_folder_name = root.name or os.path.basename(file_path)

--- a/ingestors/support/outlookpst.py
+++ b/ingestors/support/outlookpst.py
@@ -1,0 +1,80 @@
+import os
+import logging
+from email.message import EmailMessage
+from email.parser import Parser
+from email import policy
+
+import pypff
+import magic
+
+from ingestors.util import join_path, safe_path
+
+log = logging.getLogger(__name__)
+
+
+class OutlookPSTSupport(object):
+    """Provides helpers for parsing outlook data files (pst, ost etc)."""
+
+    def folder_traverse(self, parent_folder, parent_path):
+        for folder in parent_folder.sub_folders:
+            if not folder.name:
+                continue
+            new_path = os.path.join(parent_path, safe_path(folder.name))
+            os.makedirs(new_path)
+            if folder.number_of_sub_folders:
+                self.folder_traverse(folder, new_path)
+            self.check_for_messages(folder, new_path)
+
+    def handle_email_message(self, message, folder_path):
+        file_path = os.path.join(
+            folder_path, safe_path(message.subject) + '.email'
+        )
+        msg = EmailMessage()
+        if message.plain_text_body:
+            msg.set_content(message.plain_text_body)
+        if message.html_body:
+            msg.add_alternative(
+                message.html_body, maintype='text', subtype='html'
+            )
+        headers = Parser(policy=policy.default).parsestr(
+            message.transport_headers, headersonly=True
+        )
+        for key, val in headers.items():
+            if key not in msg:
+                msg.add_header(key, val)
+        for index, attachment in enumerate(message.attachments):
+            name = attachment.name or "attachment-{0}".format(index)
+            attachment_buffer = attachment.read_buffer(attachment.size)
+            ctype = magic.from_buffer(attachment_buffer, mime=True)
+            maintype, subtype = ctype.split('/', 1)
+            msg.add_attachment(
+                attachment_buffer, maintype=maintype,
+                subtype=subtype, filename=name)
+        with open(file_path, 'wb') as fp:
+            fp.write(msg.as_bytes(policy=policy.default))
+
+
+    def handle_text_message(self, message, folder_path):
+        file_path = os.path.join(folder_path, safe_path(message.subject))
+        with open(file_path, 'wb') as fp:
+            if message.html_body:
+                fp.write(message.html_body)
+            elif message.plain_text_body:
+                fp.write(message.plain_text_body)
+            elif message.rtf_body:
+                fp.write(message.rtf_body)
+        for index, attachment in enumerate(message.attachments):
+            name = attachment.name or "attachment-{0}".format(index)
+            attachment_path = os.path.join(folder_path, safe_path(name))
+            with open(attachment_path, 'wb') as fp:
+                fp.write(attachment.read_buffer(attachment.size))
+
+
+    def check_for_messages(self, folder, folder_path):
+        for message in folder.sub_messages:
+            if not message.subject:
+                continue
+            if message.transport_headers:
+                self.handle_email_message(message, folder_path)
+            else:
+                self.handle_text_message(message, folder_path)

--- a/ingestors/support/outlookpst.py
+++ b/ingestors/support/outlookpst.py
@@ -4,10 +4,9 @@ from email.message import EmailMessage
 from email.parser import Parser
 from email import policy
 
-import pypff
 import magic
 
-from ingestors.util import join_path, safe_path
+from ingestors.util import safe_path
 
 log = logging.getLogger(__name__)
 

--- a/ingestors/support/outlookpst.py
+++ b/ingestors/support/outlookpst.py
@@ -20,7 +20,6 @@ class OutlookPSTSupport(object):
             if not folder.name:
                 continue
             new_path = os.path.join(parent_path, safe_path(folder.name))
-            os.makedirs(new_path)
             if folder.number_of_sub_folders:
                 self.folder_traverse(folder, new_path)
             self.check_for_messages(folder, new_path)
@@ -31,7 +30,9 @@ class OutlookPSTSupport(object):
         )
         msg = EmailMessage()
         if message.plain_text_body:
-            msg.set_content(message.plain_text_body)
+            msg.set_content(
+                message.plain_text_body, maintype='text', subtype='plain'
+            )
         if message.html_body:
             msg.add_alternative(
                 message.html_body, maintype='text', subtype='html'
@@ -50,12 +51,16 @@ class OutlookPSTSupport(object):
             msg.add_attachment(
                 attachment_buffer, maintype=maintype,
                 subtype=subtype, filename=name)
+        if not os.path.isdir(folder_path):
+            os.makedirs(folder_path)
         with open(file_path, 'wb') as fp:
             fp.write(msg.as_bytes(policy=policy.default))
 
 
     def handle_text_message(self, message, folder_path):
         file_path = os.path.join(folder_path, safe_path(message.subject))
+        if not os.path.isdir(folder_path):
+            os.makedirs(folder_path)
         with open(file_path, 'wb') as fp:
             if message.html_body:
                 fp.write(message.html_body)

--- a/ingestors/util.py
+++ b/ingestors/util.py
@@ -2,7 +2,7 @@ import os
 import shutil
 
 from banal import decode_path
-from normality import stringify, safe_filename
+from normality import stringify
 from normality.cleaning import remove_unsafe_chars
 
 

--- a/ingestors/util.py
+++ b/ingestors/util.py
@@ -2,7 +2,7 @@ import os
 import shutil
 
 from banal import decode_path
-from normality import stringify
+from normality import stringify, safe_filename
 from normality.cleaning import remove_unsafe_chars
 
 
@@ -66,3 +66,7 @@ def remove_directory(file_path):
         shutil.rmtree(file_path, True)
     except Exception:
         pass
+
+
+def safe_path(filename):
+    return filename.replace('/', ':')


### PR DESCRIPTION
Fixes https://github.com/alephdata/ingestors/issues/13.

Some notes about the implementation:

In this implementation, we open the pst file and go through all the folders recursively. All these folders are exported to a temp directory. Similarly all the emails and other files that we can recognize are also exported to the temp directory while maintaining the folder hierarchy. Then we feed that temp directory to the DirectoryIngestor.

There are 2 issues with the implementation as far as I can see.

Ideally, we should be parsing the email files once. But with this implementation, we'll end up parsing the files twice; once to export them and then again to ingest them.

Some files are not parsed correctly. For example, some messages don't have transport headers. So they are parsed as html files. But some of these html files have attachments. I'm just exporting the attachments as separate file in the same parent folder for now. Similarly, some messages only have RTF text in them. Aleph tries to show them as PDF documents which of course fails.

To avoid parsing the files twice, I tried implementing the pst ingestor in a non-recursive way. But that didn't work out well because Aleph kind of expects it to be recursive or else doesn't create any child document for a nested result.

---

On the libpff side of things, this PR kind of depends on https://github.com/libyal/libpff/pull/69 getting merged. So I'm waiting on that to fix the build. Or else we could just build from source from a fork.