### PR TITLE
Increase the match score of email ingestor to more than html ingestor

### DIFF
--- a/ingestors/email/msg.py
+++ b/ingestors/email/msg.py
@@ -22,7 +22,7 @@ class RFC822Ingestor(Ingestor, EmailSupport):
         'email',
         'msg'
     ]
-    SCORE = 6
+    SCORE = 7
 
     def ingest(self, file_path):
         with open(file_path, 'rb') as fh:


### PR DESCRIPTION
... so that when a .eml file with text/html mime-type comes in, we will treat it as an email file and not an html file.